### PR TITLE
Code Cleanup for Inference and All Filters Page

### DIFF
--- a/d3_app.js
+++ b/d3_app.js
@@ -143,7 +143,7 @@ function show_rect(vectors, svg, x_offset, y_offset, class_name, index0, index1,
     return new_height;
 }
 
-function clean_up() {
+function cleanUp() {
     var svg = d3.select("#network");
     svg.selectAll("*").remove();
     coords = [[[]], [[]], [[]], [[]]];
@@ -185,7 +185,7 @@ function build_prev_dict(input, conv_res, args, polling_res, output) {
 
 function show_network(words, input, filters, conv_res, args, polling_res, output) {
     // clean up
-    clean_up();
+    cleanUp();
     var svg = d3.select("#network");
     var NUMBER_OF_WORDS = words.length;
     var NUMBER_OF_FILTERS = filters.length;
@@ -227,7 +227,7 @@ function show_network(words, input, filters, conv_res, args, polling_res, output
 
 function display_ww(input, label, plabel, start, same, bias) {
     // clean up
-    clean_up();
+    cleanUp();
 
     var div = d3.select(".sentences");
     if (start[0] != -1 && start[1] != -1) {

--- a/d3_new.js
+++ b/d3_new.js
@@ -1,5 +1,5 @@
 
-function draw_heatmap(query, highlight, mp) {
+function drawHeatmap(query, highlight, mp) {
 
   $("#Matrix").empty();
 

--- a/filter-demo.html
+++ b/filter-demo.html
@@ -20,6 +20,7 @@
 <script type="text/javascript" src="filter.js"></script>
 <script type="text/javascript" src="search.js"></script>
 <script type="text/javascript" src="js/all_sentence_filter_demo.js"></script>
+<script type="text/javascript" src="js/contribution_analysis.js"></script>
 <script type="text/javascript" src="sample-inputs.js"></script>
 
 <link rel="stylesheet" href="bootstrap/bootstrap.min.css">

--- a/filter-demo.html
+++ b/filter-demo.html
@@ -27,6 +27,12 @@
 <link rel="stylesheet" href="awesomplete/awesomplete.css" />
 <link rel="stylesheet" href="default.css">
 <link rel="stylesheet" href="d3_app.css">
+
+<style>
+  .d {
+    display: inline-block;
+  }
+</style>
 </head>
 
 <body>

--- a/filter.js
+++ b/filter.js
@@ -30,7 +30,7 @@ function buildSentenceEmbedding(results) {
  * @param weights
  * @param bias
  * @param len
- * @param bs - batch size
+ * @param batchSize - batch size
  * @returns {Array} - convolutional feature map
  */
 function conv(input, weights, bias, len, batchSize) {
@@ -129,17 +129,18 @@ function getConvFeatureMaps(wordvecs, weights, bias, max_len) {
 
 function displayBatchConv(batch_size, inputs, modelParams, ignore, test) {
     if (inputs[0].embedding.length < 5) {
-        clean_up();
+        cleanUp();
         return;
     }
 
     var startTime = window.performance.now();
     var L = [0, 1, 2, 3, 4];
     var batchEmbedding = inputs.map(x => x.embedding);
-    var convFeatureMaps = conv(batchEmbedding, modelParams.weights, modelParams.bias, inputs[0].embedding.length);
+    var batchSize = inputs.length;
+    var convFeatureMaps = conv(batchEmbedding, modelParams.weights, modelParams.bias, inputs[0].embedding.length, batchSize);
     var maxPoolPosAndVal = maxPooling(convFeatureMaps); // [args, pooling_res]
     var maxPoolVal = [maxPoolPosAndVal[0][1], maxPoolPosAndVal[1][1], maxPoolPosAndVal[2][1]];
-    var hiddenLayerOutput = fc1(maxPoolVal, modelParams.fc_weights, modelParams.fc_bias);  // longest time
+    var hiddenLayerOutput = fc1(maxPoolVal, modelParams.fc_weights, modelParams.fc_bias, batchSize);  // longest time
     var output = softmax(hiddenLayerOutput);
     var maxClassIndex = tf.argMax(output, 1).dataSync(); //TODO: change to data(), return promise
     var lapsed = (window.performance.now() - startTime);
@@ -173,7 +174,7 @@ function displayBatchConv(batch_size, inputs, modelParams, ignore, test) {
 
 function displaySingleConv(wordvecs, query, modelParams, test) {
     if (query.length < 5) {
-        clean_up();
+        cleanUp();
         return;
     }
 
@@ -219,15 +220,15 @@ function allFeatureActivations(wordvecs, query, modelData) {
   // word to weight, word to filter#s
 
   if (query.length < 5) {
-      clean_up();
+      cleanUp();
       return;
   }
   var convFeatureMaps = getConvFeatureMaps(wordvecs, modelData.weights, modelData.bias, wordvecs.length);
   var maxPoolPosAndVal = maxPooling(convFeatureMaps); // [args, pooling_res]
-  var vis_res = analyzeSepWidth(query, maxPoolPosAndVal);
+  var visualizationResult = analyzeSepWidth(query, maxPoolPosAndVal);
 
-  var ww = vis_res[0];
-  var mp = vis_res[1];
+  var ww = visualizationResult[0];
+  var mp = visualizationResult[1];
 
-  draw_heatmap(query, ww, mp);
+  drawHeatmap(query, ww, mp);
 }

--- a/filter.js
+++ b/filter.js
@@ -127,7 +127,7 @@ function getConvFeatureMaps(wordvecs, weights, bias, max_len) {
   return featureMaps;
 }
 
-function displayBatchConv(batch_size, inputs, modelParams, ignore, test) {
+function displayBatchConv(batchSize, inputs, modelParams, ignore, test) {
     if (inputs[0].embedding.length < 5) {
         cleanUp();
         return;
@@ -136,7 +136,6 @@ function displayBatchConv(batch_size, inputs, modelParams, ignore, test) {
     var startTime = window.performance.now();
     var L = [0, 1, 2, 3, 4];
     var batchEmbedding = inputs.map(x => x.embedding);
-    var batchSize = inputs.length;
     var convFeatureMaps = conv(batchEmbedding, modelParams.weights, modelParams.bias, inputs[0].embedding.length, batchSize);
     var maxPoolPosAndVal = maxPooling(convFeatureMaps); // [args, pooling_res]
     var maxPoolVal = [maxPoolPosAndVal[0][1], maxPoolPosAndVal[1][1], maxPoolPosAndVal[2][1]];
@@ -150,17 +149,17 @@ function displayBatchConv(batch_size, inputs, modelParams, ignore, test) {
     }
 
     var ret = [];
-    for (var i = 0; i < batch_size; i++) {
+    for (var i = 0; i < batchSize; i++) {
       var predictedLabel = L[maxClassIndex[i]];
       var ww = analyze(inputs[i].tokenized_query, maxPoolPosAndVal, maxPoolVal, modelParams.fc_weights[maxClassIndex[i]], ignore);
 
       var highlight = [];
       for (var j = 0; j < inputs[i].tokenized_query.length; j++) {
-        highlight[highlight.length] = [inputs[i].tokenized_query[j], ww[j]];
+        highlight.push([inputs[i].tokenized_query[j], ww[j]]);
       }
-      highlight[highlight.length] = ['\n', 0];
+      highlight.push(['\n', 0]);
       ret[i] = [];
-      ret[i][0] = [highlight, label[i], predictedLabel];
+      ret[i][0] = [highlight, inputs[i].label, predictedLabel];
       ret[i][1] = convFeatureMaps; // [700, 800, 900]
 
       var dim1 = [tf.squeeze(maxPoolPosAndVal[0][0]).slice([i, 0], [1, 100]).dataSync(), tf.squeeze(maxPoolPosAndVal[0][1]).slice([i, 0], [1, 100]).dataSync()];

--- a/filter.js
+++ b/filter.js
@@ -3,14 +3,14 @@ var batch_size = 32;  // default
 
 /**
  * Convert word vectors to sentence embedding
- * @param wordvecs - [[word, wordvec] ...]
+ * @param wordvecs - a list of dictionaries, each dictionary stores the word and word vector at the index
  * @returns Sentence embedding - matrix of sent length x VECTOR_LENGTH
  */
-function build_input(results) {
+function buildSentenceEmbedding(results) {
   var ret = results.map(function (result) {
-    if (result[1].length === 0) { // the word is not a top10k one
+    if (!result.word_vector) { // the word is not a top10k one
       // narrow random values down into range (-.25, .25]
-      rmatrix = [];
+      var rmatrix = [];
       for (i = 0; i < VECTOR_LENGTH; i++) {
         //rmatrix.push((Math.random()-0.5)/2);
         rmatrix.push(0);
@@ -18,7 +18,7 @@ function build_input(results) {
       return rmatrix;
     }
 
-    return result[1];
+    return result.word_vector;
   });
 
   return ret;
@@ -33,13 +33,12 @@ function build_input(results) {
  * @param bs - batch size
  * @returns {Array} - convolutional feature map
  */
-function conv(input, weights, bias, len, bs) {
-  var result = [];
-  bs = bs || batch_size;
-  var in_tensor = tf.tensor(input).as4D(bs, len, 300, 1);
+function conv(input, weights, bias, len, batchSize) {
+  var featureMaps = [];
+  var inTensor = tf.tensor(input).as4D(batchSize, len, 300, 1);
 
   for (var i = 0; i < weights.length; i++) {  // Loop over once for each filter width (3, 4, 5)
-    result[i] = [];
+    featureMaps[i] = [];
 
     // Reshape input tensor to filter width x VECTOR_LENGTH x # number of filters
     var temp = Array(i+3);
@@ -53,28 +52,28 @@ function conv(input, weights, bias, len, bs) {
       }
     }
 
-    var in_filter = tf.tensor(temp).as4D(i+3, 300, 1, 100);
+    var inFilter = tf.tensor(temp).as4D(i+3, 300, 1, 100);
     var stride = 1;
     var pad = 'valid';
 
-    result[i] = tf.conv2d(in_tensor, in_filter, stride, pad);
+    featureMaps[i] = tf.conv2d(inTensor, inFilter, stride, pad);
     var bt = tf.tensor(bias[i]).as1D();
-    var height = result[i].shape[1];
-    var stacked_bias = [];
+    var height = featureMaps[i].shape[1];
+    var stackedBias = [];
     while (height > 0) {
-      stacked_bias[stacked_bias.length] = bt;
+      stackedBias[stackedBias.length] = bt;
       height--;
     }
-    stacked_bias = tf.stack(stacked_bias);
-    result[i].add(stacked_bias);
+    stackedBias = tf.stack(stackedBias);
+    featureMaps[i].add(stackedBias);
 
-    result[i].relu();
+    featureMaps[i].relu();
   }
 
-  return result;
+  return featureMaps;
 }
 
-function max_pooling(input, ignore) {
+function maxPooling(input) {
   var res = [];
   for (var i = 0; i < input.length; i++) {  // 3
     res[i] = [input[i].argMax(1), input[i].max(1)];
@@ -83,19 +82,17 @@ function max_pooling(input, ignore) {
   return res;
 }
 
-function fc1(input, weights, bias, bs) {
+function fc1(input, weights, bias, batchSize) {
   // max pooling result
   // input: [t(100), t(100), t(100)]
   // correct
   // [t(100x100), t(100x100), t(100x100)]
-  bs = bs || batch_size;
-
-  var combined = tf.concat(input, 0).as2D(300, bs);
+  var combined = tf.concat(input, 0).as2D(300, batchSize);
   var w_tensor = tf.tensor(weights);
-  var mm = tf.matMul(w_tensor, combined).as2D(5, bs);
+  var mm = tf.matMul(w_tensor, combined).as2D(5, batchSize);
 
   var b_tensor = tf.tensor(bias).as2D(5, 1);
-  var width = bs;
+  var width = batchSize;
   var concat_bias = b_tensor;
   width--;
   while (width > 0) {
@@ -108,20 +105,8 @@ function fc1(input, weights, bias, bs) {
 }
 
 // y = w z + b;
-function soft_max(z) {
+function softmax(z) {
   return tf.softmax(z.transpose()); //[100x6]
-}
-
-function filter_max_index(max_pool) {
-  var res = [];
-  for (var dim = 0; dim < 3; dim++) { // 3
-    res[dim] = [];
-    var cur = max_pool[dim][0].dataSync();
-    for (var c = 0; c < 100; c++) { // 100
-      res[dim][c] = cur[c];
-    }
-  }
-  return res;
 }
 
 function filter_max_index_non_tensor(max_pool) {
@@ -136,151 +121,27 @@ function filter_max_index_non_tensor(max_pool) {
   return res;
 }
 
-function filter_max_weight(max_pool) {
-  var res = [];
-  for (var dim = 0; dim < 3; dim++) { // 3
-    res[dim] = [];
-    var cur = max_pool[dim][1].dataSync();
-    for (var c = 0; c < 100; c++) { // 100
-      res[dim][c] = cur[c];
-    }
-  }
-  return res;
+function getConvFeatureMaps(wordvecs, weights, bias, max_len) {
+  var sentenceEmbedding = buildSentenceEmbedding(wordvecs);
+  var featureMaps = conv(sentenceEmbedding, weights, bias, max_len, 1);
+  return featureMaps;
 }
 
-function contribution(max_pool, weight_vec, bias) {
-  var weight_exp_sum = 0;
-  for (var i = 0; i < weight_vec.length; i++) {
-    weight_exp_sum += Math.exp(weight_vec[i]);
-  }
-  weight_exp_sum += Math.exp(bias);
-
-  var res = [];
-  var ptr = 0;
-  for (var i = 0; i < 3; i++) { // 3
-    res[i] = []
-    for (var j = 0; j < 100; j++) { // 100
-      res[i][j] = Math.exp(weight_vec[ptr])/weight_exp_sum;
-      ptr++;
-    }
-  }
-
-  return res;
-}
-
-function analyze(query, max_pool_all, max_pool, fc1_res, output, interested_weight_vec, fc1_bias, ignore) {
-  // init
-  var res = Array(query.length);
-  for (var i = 0; i < query.length; i++) {
-    res[i] = 0;
-  }
-  // get weights
-  var cont = contribution(max_pool, interested_weight_vec, fc1_bias) // [ [100],[100],[100] ]
-
-  var matchedIndex = filter_max_index(max_pool_all);
-  var matchedWeight = filter_max_weight(max_pool_all);
-
-  var resByFilter = []; // 3*100
-
-  for (var i = 0; i < matchedIndex.length; i++) { // 3
-    resByFilter[i] = [];
-    for (var j = 0; j < matchedIndex[i].length; j++) {  // 100
-      var idx = matchedIndex[i][j];
-      if (i == 0) {
-        idx -= 2;
-      } else if (i == 1) {
-        idx -= 3;
-      } else {
-        idx -= 4;
-      }
-      var w = matchedWeight[i][j];
-      if (ignore) {
-        if (w <= 0.05 && w >= -0.05) {
-          continue;
-        }
-      }
-      var dim = i+3;
-      for (var k = 0; k < dim; k++) {
-        if (idx+k < 0 || idx+k >= query.length) {
-          continue;
-        }
-        res[idx+k] += w*cont[i][j];
-      }
-    }
-  }
-
-  return res;
-}
-
-function analyze_sep_width(query, max_pool_all, max_pool, fc1_res, output, interested_weight_vec, fc1_bias, ignore) {
-  // init
-  var res = Array(query.length);
-
-  var matchedIndex = filter_max_index(max_pool_all);
-  var matchedWeight = filter_max_weight(max_pool_all);
-
-  var resByFilter = []; // 3*100
-  var mapping = [];
-
-  for (var i = 0; i < matchedIndex.length; i++) { // 3
-    resByFilter[i] = [];
-    mapping[i] = [];
-    for (var k = 0; k < query.length; k++) {
-      res[k] = 0;
-      mapping[i][k] = 0;
-      resByFilter[i][k] = 0;
-    }
-    for (var j = 0; j < matchedIndex[i].length; j++) {  // 100
-      var idx = matchedIndex[i][j];
-      var w = matchedWeight[i][j];
-      if (ignore) {
-        if (w <= 0.05 && w >= -0.05) {
-          continue;
-        }
-      }
-
-      if (idx < 0 || idx >= query.length) {
-
-      } else {
-        mapping[i][idx] = Math.max(mapping[i][idx], w);
-      }
-    }
-    for (var k = 0; k < query.length; k++) {
-      //resByFilter[i][k] = parseInt(res[k]*100);
-      if (k > query.length - (i + 3) + 1) {
-        break;
-      }
-      resByFilter[i][k] = mapping[i][k];
-    }
-  }
-
-  return [resByFilter, mapping];
-}
-
-function get_conv_res(wordvecs, weights, bias, max_len) {
-  var sentenceEmbedding = build_input(wordvecs);
-  var conv_res = conv(sentenceEmbedding, weights, bias, max_len, 1);
-  return conv_res;
-}
-
-function display_conv_batch(batch, max_len, label, results, query, weights, bias, weights_fc1, bias_fc1, ignore, test) {
-    if (query.length < 5) {
+function displayBatchConv(batch_size, inputs, modelParams, ignore, test) {
+    if (inputs[0].embedding.length < 5) {
         clean_up();
         return;
     }
 
     var startTime = window.performance.now();
     var L = [0, 1, 2, 3, 4];
-    var conv_res = conv(results, weights, bias, max_len);
-
-    var max_pool_res = max_pooling(conv_res, ignore); // [args, pooling_res]
-
-    var max_pool_res_real = [max_pool_res[0][1], max_pool_res[1][1], max_pool_res[2][1]];
-
-    var fc1_res = fc1(max_pool_res_real, weights_fc1, bias_fc1);  // longest time
-
-    var output = soft_max(fc1_res);
-    var res_index = tf.argMax(output, 1).dataSync(); //TODO: change to data(), return promise
+    var batchEmbedding = inputs.map(x => x.embedding);
+    var convFeatureMaps = conv(batchEmbedding, modelParams.weights, modelParams.bias, inputs[0].embedding.length);
+    var maxPoolPosAndVal = maxPooling(convFeatureMaps); // [args, pooling_res]
+    var maxPoolVal = [maxPoolPosAndVal[0][1], maxPoolPosAndVal[1][1], maxPoolPosAndVal[2][1]];
+    var hiddenLayerOutput = fc1(maxPoolVal, modelParams.fc_weights, modelParams.fc_bias);  // longest time
+    var output = softmax(hiddenLayerOutput);
+    var maxClassIndex = tf.argMax(output, 1).dataSync(); //TODO: change to data(), return promise
     var lapsed = (window.performance.now() - startTime);
 
     if (test) {
@@ -289,33 +150,28 @@ function display_conv_batch(batch, max_len, label, results, query, weights, bias
 
     var ret = [];
     for (var i = 0; i < batch_size; i++) {
-      var interested_weight_vec = weights_fc1[res_index[i]];
-
-      var predictedlabel = L[res_index[i]];
-
-      var ww = analyze(query[i], max_pool_res, max_pool_res_real, bias_fc1, output,
-                      interested_weight_vec, bias_fc1[res_index[i]], ignore);
+      var predictedLabel = L[maxClassIndex[i]];
+      var ww = analyze(inputs[i].tokenized_query, maxPoolPosAndVal, maxPoolVal, modelParams.fc_weights[maxClassIndex[i]], ignore);
 
       var highlight = [];
-      for (var j = 0; j < query[i].length; j++) {
-        highlight[highlight.length] = [query[i][j], ww[j]];
+      for (var j = 0; j < inputs[i].tokenized_query.length; j++) {
+        highlight[highlight.length] = [inputs[i].tokenized_query[j], ww[j]];
       }
       highlight[highlight.length] = ['\n', 0];
       ret[i] = [];
-      ret[i][0] = [highlight, label[i], predictedlabel];
-      ret[i][1] = conv_res; // [700, 800, 900]
+      ret[i][0] = [highlight, label[i], predictedLabel];
+      ret[i][1] = convFeatureMaps; // [700, 800, 900]
 
-      var dim1 = [tf.squeeze(max_pool_res[0][0]).slice([i, 0], [1, 100]).dataSync(), tf.squeeze(max_pool_res[0][1]).slice([i, 0], [1, 100]).dataSync()];
-      var dim2 = [tf.squeeze(max_pool_res[1][0]).slice([i, 0], [1, 100]).dataSync(), tf.squeeze(max_pool_res[1][1]).slice([i, 0], [1, 100]).dataSync()];
-      var dim3 = [tf.squeeze(max_pool_res[2][0]).slice([i, 0], [1, 100]).dataSync(), tf.squeeze(max_pool_res[2][1]).slice([i, 0], [1, 100]).dataSync()];
+      var dim1 = [tf.squeeze(maxPoolPosAndVal[0][0]).slice([i, 0], [1, 100]).dataSync(), tf.squeeze(maxPoolPosAndVal[0][1]).slice([i, 0], [1, 100]).dataSync()];
+      var dim2 = [tf.squeeze(maxPoolPosAndVal[1][0]).slice([i, 0], [1, 100]).dataSync(), tf.squeeze(maxPoolPosAndVal[1][1]).slice([i, 0], [1, 100]).dataSync()];
+      var dim3 = [tf.squeeze(maxPoolPosAndVal[2][0]).slice([i, 0], [1, 100]).dataSync(), tf.squeeze(maxPoolPosAndVal[2][1]).slice([i, 0], [1, 100]).dataSync()];
       ret[i][2] = [dim1, dim2, dim3]; // [[2],[2],[2]]
     }
 
     return ret;
 }
 
-function display_single_conv(wordvecs, query, weights, bias, weights_fc1, bias_fc1, test) {
-
+function displaySingleConv(wordvecs, query, modelParams, test) {
     if (query.length < 5) {
         clean_up();
         return;
@@ -323,30 +179,29 @@ function display_single_conv(wordvecs, query, weights, bias, weights_fc1, bias_f
 
     var startTime = window.performance.now();
     var L = [0, 1, 2, 3, 4];
-    var batch_size = 1;
-    var conv_res = get_conv_res(wordvecs, weights, bias, wordvecs.length);
-    // conv_res is [w3 feat maps, w4 feat maps, w5 feat maps]
+    var batchSize = 1;
+    // convFeatureMaps is [w3 feat maps, w4 feat maps, w5 feat maps]
+    var convFeatureMaps = getConvFeatureMaps(wordvecs, modelParams.weights, modelParams.bias, wordvecs.length);
 
-    var max_pool_res = max_pooling(conv_res); // list of 3 items of [args, max_values]
+    var maxPoolPosAndVal = maxPooling(convFeatureMaps); // list of 3 items of [args, max_values]
+    // console.log(maxPoolPosAndVal[0][1]) -> max pooling res of 3 dim filter, 100 max values
+    var maxPoolVal = [maxPoolPosAndVal[0][1], maxPoolPosAndVal[1][1], maxPoolPosAndVal[2][1]];
 
-    // console.log(max_pool_res[0][1]) -> max pooling res of 3 dim filter, 100 max values
-    var max_pool_res_real = [max_pool_res[0][1], max_pool_res[1][1], max_pool_res[2][1]];
+    var hiddenLayerOutput = fc1(maxPoolVal, modelParams.fc_weights, modelParams.fc_bias, batchSize);
+    var output = softmax(hiddenLayerOutput);
 
-    var fc1_res = fc1(max_pool_res_real, weights_fc1, bias_fc1, batch_size);
-    var output = soft_max(fc1_res);
-
-    var res_index = tf.argMax(output, 1).dataSync();
+    var maxClassIndex = tf.argMax(output, 1).dataSync();
     var lapsed = (window.performance.now() - startTime);
 
     if (test) {
       return lapsed;
     }
 
-    var predictedlabel = L[res_index];
+    var predictedLabel = L[maxClassIndex];
     var queryString = query.join(' ');
-    var actuallabel = sampleInputs.find(d => d.sentence === queryString).label;
+    var actualLabel = sampleInputs.find(d => d.sentence === queryString).label;
 
-    $('#inference-result').html(`Predicted: ${predictedlabel} \t Actual: ${actuallabel}`);
+    $('#inference-result').html(`Predicted: ${predictedLabel} \t Actual: ${actualLabel}`);
 }
 
 function display_sentence_coloring(highlight, label, predictedlabel, start, areSame, bias) {
@@ -355,11 +210,11 @@ function display_sentence_coloring(highlight, label, predictedlabel, start, areS
 
 /**
  *
- * @param wordvecs - [[word, wordvec] ...]
+ * @param wordvecs - a list of dictionaries, each dictionary stores the word and word vector at the index
  * @param query - tokenized sentence as list of tokens
  * @param modelData - object containing model parameters and dev dataset
  */
-function all_feature_activations(wordvecs, query, modelData) {
+function allFeatureActivations(wordvecs, query, modelData) {
   // for each width (3, 4, 5)
   // word to weight, word to filter#s
 
@@ -367,20 +222,9 @@ function all_feature_activations(wordvecs, query, modelData) {
       clean_up();
       return;
   }
-  var batch_size = 1;
-  var conv_res = get_conv_res(wordvecs, modelData.weights, modelData.bias, wordvecs.length);
-
-  var max_pool_res = max_pooling(conv_res); // [args, pooling_res]
-  var max_pool_res_real = [max_pool_res[0][1], max_pool_res[1][1], max_pool_res[2][1]];
-
-  var fc1_res = fc1(max_pool_res_real, modelData.fc_weights, modelData.fc_bias, batch_size);
-  var output = soft_max(fc1_res);
-  var res_index = tf.argMax(output, 1).dataSync();
-
-  var interested_weight_vec = modelData.fc_weights[res_index];
-
-  var vis_res = analyze_sep_width(query, max_pool_res, max_pool_res_real, fc1_res, output,
-                  interested_weight_vec, modelData.fc_bias[res_index]);
+  var convFeatureMaps = getConvFeatureMaps(wordvecs, modelData.weights, modelData.bias, wordvecs.length);
+  var maxPoolPosAndVal = maxPooling(convFeatureMaps); // [args, pooling_res]
+  var vis_res = analyzeSepWidth(query, maxPoolPosAndVal);
 
   var ww = vis_res[0];
   var mp = vis_res[1];

--- a/js/all_sentence_filter_demo.js
+++ b/js/all_sentence_filter_demo.js
@@ -15,7 +15,6 @@ $(document).ready(function() {
 
       var showAll = function(ignore, b_index, test) {
         document.getElementById("sent").innerHTML = "";
-        updateMsg("Started processing sentences.");
 
         batch_size = batch_size || 64;
         b_index = b_index || 0;
@@ -34,6 +33,7 @@ $(document).ready(function() {
         });
 
         Promise.all(requests).then(function(inputs) {
+          console.log('all promises resolved');
           wordvec_time = window.performance.now() - startTime;
 
           // Build sentence embedding for each query
@@ -77,8 +77,7 @@ $(document).ready(function() {
             }
           } else {
             startTime = window.performance.now();
-            let timeElapsed = displayBatchConv(batch_size, inputs, modelData, ignore, false);
-
+            let ret = displayBatchConv(batch_size, inputs, modelData, ignore, false);
             if ((b_index+1)*batch_size+batch_size > modelData.dev_sentences.length) {
               updateMsg("Finished processing " + inputs.length + " sentences in " + ret + "ms.");
               for (var i = 0; i < ret.length; i++) {

--- a/js/all_sentence_filter_demo.js
+++ b/js/all_sentence_filter_demo.js
@@ -33,7 +33,6 @@ $(document).ready(function() {
         });
 
         Promise.all(requests).then(function(inputs) {
-          console.log('all promises resolved');
           wordvec_time = window.performance.now() - startTime;
 
           // Build sentence embedding for each query
@@ -78,16 +77,13 @@ $(document).ready(function() {
           } else {
             startTime = window.performance.now();
             let ret = displayBatchConv(batch_size, inputs, modelData, ignore, false);
+            for (var i = 0; i < ret.length; i++) {
+              nn_res.push(ret[i]);
+            }
             if ((b_index+1)*batch_size+batch_size > modelData.dev_sentences.length) {
-              updateMsg("Finished processing " + inputs.length + " sentences in " + ret + "ms.");
-              for (var i = 0; i < ret.length; i++) {
-                nn_res[nn_res.length] = ret[i];
-              }
               updateMsg("Done");
             } else {
-              for (var i = 0; i < ret.length; i++) {
-                nn_res[nn_res.length] = ret[i];
-              }
+              updateMsg("Finished processing batch " + b_index);
               showAll(undefined, b_index+1, false)
             }
           }

--- a/js/contribution_analysis.js
+++ b/js/contribution_analysis.js
@@ -1,0 +1,128 @@
+function filterMaxIndex(max_pool) {
+  var res = [];
+  for (var dim = 0; dim < 3; dim++) { // 3
+    res[dim] = [];
+    var cur = max_pool[dim][0].dataSync();
+    for (var c = 0; c < 100; c++) { // 100
+      res[dim][c] = cur[c];
+    }
+  }
+  return res;
+}
+
+function filterMaxWeight(max_pool) {
+  var res = [];
+  for (var dim = 0; dim < 3; dim++) { // 3
+    res[dim] = [];
+    var cur = max_pool[dim][1].dataSync();
+    for (var c = 0; c < 100; c++) { // 100
+      res[dim][c] = cur[c];
+    }
+  }
+  return res;
+}
+
+/**
+ * Get "contribution" of each feature map towards the prediction of a class
+ * @param maxPoolVal - output values of max pooling
+ * @param weightVec - a vector whose length is equal to the number of feature maps
+ * @returns {Array} denoting the "contribution" of each feature map
+ */
+function contribution(maxPoolVal, weightVec) {
+  var normalizingDenominator = 0;
+  for (var i = 0; i < weightVec.length; i++) {
+    normalizingDenominator += Math.exp(weightVec[i]);
+  }
+
+  var res = [];
+  for (var i = 0; i < 3; i++) { // 3
+    res[i] = [];
+    for (var j = 0; j < 100; j++) { // 100
+      res[i][j] = Math.exp(weightVec[i*100+j]) / normalizingDenominator;
+    }
+  }
+
+  return res;
+}
+
+function analyze(tokenizedQuery, maxPoolPosAndVal, maxPoolVal, interestedWeightVec, ignore) {
+  // init
+  var res = Array(tokenizedQuery.length).fill(0);
+
+  // get weights
+  var cont = contribution(maxPoolVal, interestedWeightVec); // [ [100],[100],[100] ]
+
+  var matchedIndex = filterMaxIndex(maxPoolPosAndVal);
+  var matchedWeight = filterMaxWeight(maxPoolPosAndVal);
+
+  for (var i = 0; i < matchedIndex.length; i++) { // 3
+    for (var j = 0; j < matchedIndex[i].length; j++) {  // 100
+      var idx = matchedIndex[i][j];
+      if (i === 0) {
+        idx -= 2;
+      } else if (i === 1) {
+        idx -= 3;
+      } else {
+        idx -= 4;
+      }
+      var w = matchedWeight[i][j];
+      if (ignore && w <= 0.05 && w >= -0.05) {
+        continue;
+      }
+      var dim = i+3;
+      for (var k = 0; k < dim; k++) {
+        if (idx+k < 0 || idx+k >= tokenizedQuery.length) {
+          continue;
+        }
+        res[idx+k] += w*cont[i][j];
+      }
+    }
+  }
+
+  return res;
+}
+
+function analyzeSepWidth(query, maxPoolPosAndVal, ignore) {
+  // init
+  var res = Array(query.length);
+
+  var matchedIndex = filterMaxIndex(maxPoolPosAndVal);
+  var matchedWeight = filterMaxWeight(maxPoolPosAndVal);
+
+  var resByFilter = []; // 3*100
+  var mapping = [];
+
+  for (var i = 0; i < matchedIndex.length; i++) { // 3
+    resByFilter[i] = [];
+    mapping[i] = [];
+    for (var k = 0; k < query.length; k++) {
+      res[k] = 0;
+      mapping[i][k] = 0;
+      resByFilter[i][k] = 0;
+    }
+    for (var j = 0; j < matchedIndex[i].length; j++) {  // 100
+      var idx = matchedIndex[i][j];
+      var w = matchedWeight[i][j];
+      if (ignore) {
+        if (w <= 0.05 && w >= -0.05) {
+          continue;
+        }
+      }
+
+      if (idx < 0 || idx >= query.length) {
+
+      } else {
+        mapping[i][idx] = Math.max(mapping[i][idx], w);
+      }
+    }
+    for (var k = 0; k < query.length; k++) {
+      //resByFilter[i][k] = parseInt(res[k]*100);
+      if (k > query.length - (i + 3) + 1) {
+        break;
+      }
+      resByFilter[i][k] = mapping[i][k];
+    }
+  }
+
+  return [resByFilter, mapping];
+}

--- a/js/search_demo.js
+++ b/js/search_demo.js
@@ -4,14 +4,13 @@ $(document).ready(function() {
       // Querying
       var searchButton = function() {
         document.getElementById("sent").innerHTML = "";
-        var q = document.querySelector("#query").value.split(" ");
-        q = q.filter(function(x) { return x.length > 0 }).map(function(x) { return x.toLowerCase() });
+        var q = document.querySelector("#query").value.split(" ").filter(x => x.length).map(x => x.toLowerCase());
 
         // Get word vectors
         var startTime = window.performance.now();
         searcher.showVecs(q, Array(), function(wordvecs) {
           updateMsg("Started processing sentence: " + q);
-          display_single_conv(wordvecs, q, modelData.weights, modelData.bias, modelData.fc_weights, modelData.fc_bias);
+          displaySingleConv(wordvecs, q, modelData);
           updateMsg("Finished processing sentence in: " + (window.performance.now() - startTime) + "ms.");
           // display_cnn(results, q);
         });

--- a/js/single_sentence_filter_demo.js
+++ b/js/single_sentence_filter_demo.js
@@ -3,18 +3,15 @@ $(document).ready(function() {
     setup(modelData => {
       // Querying
       var searchButton = function() {
-        var q = document.querySelector("#query").value.split(" ");
-        if (q.length == 1 && q[0] == "") {
-          q = "it 's a remarkably solid and subtly satirical tour de force .".split(" ");
-        }
-        q = q.filter(function(x) { return x.length > 0 }).map(function(x) { return x.toLowerCase() });
+        var q = document.querySelector("#query").value.split(" ").filter(x => x.length).map(x => x.toLowerCase());
 
         // Get word vectors
         searcher.showVecs(q, Array(), function(wordvecs) {
           var startTime = window.performance.now();
           updateMsg("Started processing sentence: " + q);
+          console.log('retrieved');
 
-          all_feature_activations(wordvecs, q, modelData);
+          allFeatureActivations(wordvecs, q, modelData);
           updateMsg("Finished processing sentence in: " + (window.performance.now() - startTime) + "ms.");
         });
       };

--- a/kimcnn-demo.html
+++ b/kimcnn-demo.html
@@ -21,6 +21,7 @@
 <script type="text/javascript" src="matrix.js"></script>
 <script type="text/javascript" src="search.js"></script>
 <script type="text/javascript" src="js/single_sentence_filter_demo.js"></script>
+<script type="text/javascript" src="js/contribution_analysis.js"></script>
 <script type="text/javascript" src="sample-inputs.js"></script>
 
 <link rel="stylesheet" href="bootstrap/bootstrap.min.css">

--- a/search.js
+++ b/search.js
@@ -60,9 +60,8 @@ var searcher = (function () {
       var res = e.target.result;
       if (res) {
         sentence = res.value.comment;
-        label = res.value.label;
         sentences[sentences.length] = sentence;
-        labels[labels.length] = label;
+        labels[labels.length] = res.value.label;
         getAllSentences(callback, i+1);
       } else {
         callback(sentences, labels);

--- a/search.js
+++ b/search.js
@@ -1,13 +1,11 @@
 var searcher = (function () {
   var phrases;
-  var phrasesAll;
-  var numDocs = 0;
   var sentence;
   var sentences;
   var labels;
 
   function wordvecsSearchInit(callback, q, results, i) {
-    if (i == q.length) {
+    if (i === q.length) {
       callback(results);
       return;
     }
@@ -16,14 +14,21 @@ var searcher = (function () {
       .objectStore("wordvecs")
       .openCursor(q[i]);
 
+    // TODO: this is forcing one retrieval to follow the next.
+    // would it more efficient to do this asynchronously?
     cursor.onsuccess = function (e) {
       var res = e.target.result;
       if (res) {
-        results[results.length] = Array(q[i], res.value);
-        res.continue;
+        results.push({
+          word: q[i],
+          word_vector: res.value
+        });
       } else {
-        // console.log("Word2Vec not found for word: " + phrases[i]);
-        results[results.length] = Array(q[i], Array());
+        // console.log("Word vector not found for word: " + phrases[i]);
+        results.push({
+          word: q[i],
+          word_vector: undefined
+        });
       }
       wordvecsSearchInit(callback, q, results, i + 1);
     };
@@ -42,23 +47,6 @@ var searcher = (function () {
         res.continue();
       } else {
         callback(result);
-      }
-    };
-  }
-
-  function getithSentence(index, callback) {
-    var cursor = db.transaction(["dataset"], "readonly")
-      .objectStore("dataset")
-      .openCursor(index);
-
-    cursor.onsuccess = function (e) {
-      var res = e.target.result;
-      if (res) {
-        sentence = res.value.comment;
-        label = res.value.label;
-        callback(sentence, label);
-      } else {
-        console.log("No more sentences");
       }
     };
   }
@@ -88,11 +76,6 @@ var searcher = (function () {
       searchAllParams(callback);
     },
 
-    getSentence: function (i, callback) {
-      sentence = "";
-      getithSentence(i, callback);
-    },
-
     getSentenceAll: function (callback) {
       sentences = [];
       labels = [];
@@ -102,15 +85,6 @@ var searcher = (function () {
     showVecs: function (q, res, callback) {
       phrases = q;
       wordvecsSearchInit(callback, q, res, 0);
-    },
-
-    showVecsAll: function (qs, callback) {
-      phrasesAll = qs;
-      wordvecsSearchInit(callback, 0);
-    },
-
-    setNumDocs: function (n) {
-      numDocs = n;
     },
   };
 


### PR DESCRIPTION
* Separate "analysis" code into its own file since `filter.js` is getting too large
* Delete extraneous unused variables in method parameters and reduce reliance on global variables
* Switching [prop1, prop2, ...] convention to dictionary. It is not really clear from reading the code what each positions stores by looking at the code, especially since types in JS are not declared. Instead, we use dictionary whenever possible so we know exactly what each key-value pair is storing. This PR refactors doesn't completely refactor all occurrences but most of the places that the inference and all filters page touch are fixed.
* Use same variable naming convention for consistency. We have camelCase in some places but snake_case in others. The convention we should follow is camelCase for variable names and snake_case for object properties. This PR refactors doesn't completely refactor all occurrences but most of the places that the inference and all filters page touch are fixed.
* Bug fix - label for all filters page was removed accidentally in an earlier PR
* General fixes